### PR TITLE
Extend API to manipulate prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ Alternatively, use the ``get`` method:
     >>> pyt.get("10.0.0.0/24")
     'a'
 
+If you want access to the key instead (i.e. the longest matching prefix), use ``get_key``:
+
+    >>> pyt.get_key("10.1.0.0/16")
+    '10.1.0.0/16'
+    >>> pyt.get_key("10.1.0.0/24")
+    '10.1.0.0/16'
+    >>> pyt.get_key("10.1.0.0/32")
+    '10.1.0.0/16'
+    >>> pyt.get_key("10.0.0.0/24")
+    '10.0.0.0/8'
+
 The ``del`` operator works as it does with Python dictionaries (and there is also a ``delete`` method that works similarly):
 
     >>> del pyt["10.0.0.0/8"]
@@ -133,6 +144,26 @@ The ``has_key`` method is also implement, but it's important to note that the be
     >>> '10.0.0.0/8' in pyt
     True
     >>> 
+
+It is also possible to find the ``parent`` and ``children`` of a given prefix in the tree.  Similarly to the ``has_key`` method, the prefix must be present as an exact match in the tree.  For instance:
+
+    >>> pyt.parent('10.1.0.0/16')
+    '10.0.0.0/8'
+    >>> pyt.parent('10.0.0.0/8')
+    None
+    >>> pyt["10.1.1.0/24"] = 'c'
+    >>> pyt.children('10.0.0.0/8')
+    ['10.1.0.0/16', '10.1.1.0/24']
+    >>> pyt.children('10.1.0.0/16')
+    ['10.1.1.0/24']
+    >>> pyt.children('10.1.1.0/24')
+    []
+    >>> pyt.parent('10.1.42.0/24')
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    KeyError: Prefix doesn't exist.
+
+If you want to get the longest matching prefix for arbitrary prefixes, you should use ``get_key``, not ``parent``.
 
 A ``PyTricia`` object is *almost* like a dictionary, but not quite.   You can extract the keys, but not the values:
 

--- a/pytricia.c
+++ b/pytricia.c
@@ -574,6 +574,40 @@ pytricia_children(register PyTricia *self, PyObject *args) {
     return rvlist;
 }
 
+static PyObject*
+pytricia_parent(register PyTricia *self, PyObject *args) {
+    PyObject *key = NULL;
+
+    if (!PyArg_ParseTuple(args, "O", &key)) {
+        return NULL;
+    }
+
+    prefix_t *prefix = _key_object_to_prefix(key);
+    if (!prefix) {
+        return NULL;
+    }
+
+    patricia_node_t* node = patricia_search_exact(self->m_tree, prefix);
+    Deref_Prefix(prefix);
+    if (!node) {
+	PyErr_SetString(PyExc_KeyError, "Prefix doesn't exist.");
+	return NULL;
+    }
+    patricia_node_t* parent_node = patricia_search_best2(self->m_tree, node->prefix, 0);
+    if (!parent_node) {
+        Py_RETURN_NONE;
+    }
+
+    char buffer[64];
+    prefix_toa2x(parent_node->prefix, buffer, 1);
+    PyObject *item = Py_BuildValue("s", buffer);
+    if (!item) {
+	return NULL;
+    }
+    Py_INCREF(item);
+    return item;
+}
+
 static PyMappingMethods pytricia_as_mapping = {
     (lenfunc)pytricia_length,
     (binaryfunc)pytricia_subscript,
@@ -606,6 +640,7 @@ static PyMethodDef pytricia_methods[] = {
     {"delete", (PyCFunction)pytricia_delitem, METH_VARARGS, "delete(prefix) -> \nDelete mapping associated with prefix.\n"},
     {"insert", (PyCFunction)pytricia_insert, METH_VARARGS, "insert(prefix, data) -> data\nCreate mapping between prefix and data in tree."},
     {"children", (PyCFunction)pytricia_children, METH_VARARGS, "children(prefix) -> list\nReturn a list of all prefixes that are more specific than the given prefix (the prefix must be present as an exact match)."},
+    {"parent", (PyCFunction)pytricia_parent, METH_VARARGS, "parent(prefix) -> prefix\nReturn the immediate parent of the given prefix (the prefix must be present as an exact match)."},
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/test.py
+++ b/test.py
@@ -295,6 +295,24 @@ class PyTriciaTests(unittest.TestCase):
             self.assertEqual(pyt.get(IPv6Network("fe80:abcd::0/96")), "xyz")
             self.assertEqual(pyt.get(IPv6Network("fe80:beef::0/96")), "abc")
 
+    def testGetKey(self):
+        pyt = pytricia.PyTricia()
+        pyt.insert("10.0.0.0/8", "a")
+        self.assertEqual(pyt.get_key("10.0.0.0/8"), "10.0.0.0/8")
+        self.assertEqual(pyt.get_key("10.42.42.42"), "10.0.0.0/8")
+        self.assertIsNone(pyt.get_key("11.0.0.0/8"))
+        pyt.insert("10.42.0.0/16", "b")
+        self.assertEqual(pyt.get_key("10.42.42.42"), "10.42.0.0/16")
+
+    def testGetKeyIP6(self):
+        pyt = pytricia.PyTricia(128)
+        pyt.insert("2001:db8:10::/48", "a")
+        self.assertEqual(pyt.get_key("2001:db8:10::/48"), "2001:db8:10::/48")
+        self.assertEqual(pyt.get_key("2001:db8:10:42::1"), "2001:db8:10::/48")
+        self.assertIsNone(pyt.get_key("2001:db8:11::/48"))
+        pyt.insert("2001:db8:10:42::/64", "b")
+        self.assertEqual(pyt.get_key("2001:db8:10:42::1"), "2001:db8:10:42::/64")
+
     def testChildren(self):
         pyt = pytricia.PyTricia()
         pyt.insert("42.0.0.0/8", "0")

--- a/test.py
+++ b/test.py
@@ -295,6 +295,36 @@ class PyTriciaTests(unittest.TestCase):
             self.assertEqual(pyt.get(IPv6Network("fe80:abcd::0/96")), "xyz")
             self.assertEqual(pyt.get(IPv6Network("fe80:beef::0/96")), "abc")
 
+    def testChildren(self):
+        pyt = pytricia.PyTricia()
+        pyt.insert("42.0.0.0/8", "0")
+        pyt.insert("42.100.0.0/16", "1")
+        pyt.insert("10.0.0.0/8", "a")
+        pyt.insert("10.100.0.0/16", "b")
+        pyt.insert("10.100.100.0/24", "c")
+        pyt.insert("10.101.0.0/16", "d")
+        self.assertListEqual(sorted(["10.100.0.0/16", "10.100.100.0/24", "10.101.0.0/16"]), sorted(pyt.children("10.0.0.0/8")))
+        self.assertListEqual(["10.100.100.0/24"], pyt.children("10.100.0.0/16"))
+        self.assertListEqual([], pyt.children("10.100.100.0/24"))
+        with self.assertRaises(KeyError) as cm:
+            pyt.children("10.42.42.0/24")
+        self.assertIsInstance(cm.exception, KeyError)
+
+    def testChildrenIp6(self):
+        pyt = pytricia.PyTricia(128)
+        pyt.insert("2001:db8:42::/48", "0")
+        pyt.insert("2001:db8:42:100::/64", "1")
+        pyt.insert("2001:db8:10::/48", "a")
+        pyt.insert("2001:db8:10:100::/64", "b")
+        pyt.insert("2001:db8:10:100:100::/96", "c")
+        pyt.insert("2001:db8:10:101::/64", "d")
+        self.assertListEqual(sorted(["2001:db8:10:100::/64", "2001:db8:10:100:100::/96", "2001:db8:10:101::/64"]), sorted(pyt.children("2001:db8:10::/48")))
+        self.assertListEqual(["2001:db8:10:100:100::/96"], pyt.children("2001:db8:10:100::/64"))
+        self.assertListEqual([], pyt.children("2001:db8:10:100:100::/96"))
+        with self.assertRaises(KeyError) as cm:
+            pyt.children("2001:db8:10:42:42::/96")
+        self.assertIsInstance(cm.exception, KeyError)
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/test.py
+++ b/test.py
@@ -343,6 +343,30 @@ class PyTriciaTests(unittest.TestCase):
             pyt.children("2001:db8:10:42:42::/96")
         self.assertIsInstance(cm.exception, KeyError)
 
+    def testParent(self):
+        pyt = pytricia.PyTricia()
+        pyt.insert("10.0.0.0/8", "a")
+        pyt.insert("10.100.0.0/16", "b")
+        pyt.insert("10.100.100.0/24", "c")
+        self.assertIsNone(pyt.parent("10.0.0.0/8"))
+        self.assertEqual("10.0.0.0/8", pyt.parent("10.100.0.0/16"))
+        self.assertEqual("10.100.0.0/16", pyt.parent("10.100.100.0/24"))
+        with self.assertRaises(KeyError) as cm:
+            pyt.parent("10.42.42.0/24")
+        self.assertIsInstance(cm.exception, KeyError)
+
+    def testParentIP6(self):
+        pyt = pytricia.PyTricia(128)
+        pyt.insert("2001:db8:10::/48", "a")
+        pyt.insert("2001:db8:10:100::/64", "b")
+        pyt.insert("2001:db8:10:100:100::/96", "c")
+        self.assertIsNone(pyt.parent("2001:db8:10::/48"))
+        self.assertEqual("2001:db8:10::/48", pyt.parent("2001:db8:10:100::/64"))
+        self.assertEqual("2001:db8:10:100::/64", pyt.parent("2001:db8:10:100:100::/96"))
+        with self.assertRaises(KeyError) as cm:
+            pyt.parent("2001:db8:42:42::/64")
+        self.assertIsInstance(cm.exception, KeyError)
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Currently, most methods only give access to the values, but not to the keys (prefixes).  The new methods implemented here allow to find the longest matching prefix, the parent prefix, and the children prefixes (i.e. all more specific prefixes).

The new methods have been tested with python 2.7 and python 3.4.

This pull request is obviously open to discussions.  For instance, `children` currently returns all children prefixes recursively, but it could also be useful to return only the immediate children (maybe by passing a `recursive` boolean to the method?).

More generally, it could be interesting to switch to Python to implement complex operations, for instance finding all leaves of a tree, or generating a recursive iterator on children.  It would require thinking about the minimum set of basic operations that must be implemented in C.
