### PR TITLE
search_best: fix inclusion of too large prefixes

### DIFF
--- a/patricia.c
+++ b/patricia.c
@@ -648,7 +648,7 @@ patricia_search_best2 (patricia_tree_t *patricia, prefix_t *prefix, int inclusiv
 		break;
 	}
 
-	if (inclusive && node && node->prefix)
+	if (inclusive && node && node->prefix && node->bit <= bitlen)
 	stack[cnt++] = node;
 
 #ifdef PATRICIA_DEBUG


### PR DESCRIPTION
patricia_search_best: inclusive search should not include a prefix that is too big