### PR TITLE
Add (bytes, size) input/output to all functions

### DIFF
--- a/pytricia.c
+++ b/pytricia.c
@@ -303,7 +303,10 @@ _prefix_to_key_object(prefix_t* prefix, int raw_output) {
 #else
         value = PyString_FromStringAndSize(addr, addr_size);
 #endif
-        return Py_BuildValue("(Oi)", value, prefix->bitlen);
+        PyObject* tuple;
+        tuple = Py_BuildValue("(Oi)", value, prefix->bitlen);
+        Py_XDECREF(value);
+        return tuple;
     }
     char buffer[64];
     prefix_toa2x(prefix, buffer, 1);


### PR DESCRIPTION
Hi, I don't know if this feature will be interesting to you. I have added the possibility to use "raw" input and output for prefixes.

All functions accept prefixes as tuples (bytes, size) as input as well as the normal CIDR string format.

I have also added a raw_output argument to the PytriciaTree class init. It defaults to False. When set to True, the prefixes output by each function are tuples (bytes, size) instead of CIDR strings.

I have added tests that show how the feature can be used. I use this library in an application that manipulates addresses a lot, and converting them to CIDRs and back to bytes is time-consuming.

If you are interested in adding features to the library, I have another function "find_children" a bit more flexible than the current "children" function (works if the prefix is not in the tree, and has an option to include grandchildren or not). I could make another pull request, but it depends on this one.