### PR TITLE
Allow short but valid IPv6 addresses, add tests.

### DIFF
--- a/pytricia.c
+++ b/pytricia.c
@@ -79,10 +79,6 @@ _prefix_convert(int family, const char *addr, prefix_t* prefix) {
     int prefixlen = -1;
     char addrcopy[128];
 
-    if (strlen(addr) < 4) {
-        return 0;
-    } 
-
     strncpy(addrcopy, addr, 128);
     char *slash = strchr(addrcopy, '/');
     if (slash != NULL) {

--- a/pytricia.c
+++ b/pytricia.c
@@ -79,6 +79,10 @@ _prefix_convert(int family, const char *addr, prefix_t* prefix) {
     int prefixlen = -1;
     char addrcopy[128];
 
+    if (strlen(addr) < 2) {
+        return 0;
+    }
+
     strncpy(addrcopy, addr, 128);
     char *slash = strchr(addrcopy, '/');
     if (slash != NULL) {

--- a/test.py
+++ b/test.py
@@ -284,7 +284,7 @@ class PyTriciaTests(unittest.TestCase):
             val = pyt.insert("fe80::1") # should raise an exception
 
     def testInsertValidShortV6(self):
-        pyt = pytricia.PyTricia()
+        pyt = pytricia.PyTricia(128)
         val = pyt.insert("::2", "a") # A valid short IPv6 address should succeed
         self.assertIs(val, None)
         self.assertEqual(len(pyt), 1)
@@ -292,7 +292,7 @@ class PyTriciaTests(unittest.TestCase):
         self.assertIn("::2", pyt)
 
     def testInsertInvalidShortV6(self):
-        pyt = pytricia.PyTricia()
+        pyt = pytricia.PyTricia(128)
         with self.assertRaisesRegex(ValueError, "Invalid key.") as cm:
             val = pyt.insert(":2:", "a") # should raise an exception
 

--- a/test.py
+++ b/test.py
@@ -283,6 +283,24 @@ class PyTriciaTests(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             val = pyt.insert("fe80::1") # should raise an exception
 
+    def testInsertValidShortV6(self):
+        pyt = pytricia.PyTricia()
+        val = pyt.insert("::2", "a") # A valid short IPv6 address should succeed
+        self.assertIs(val, None)
+        self.assertEqual(len(pyt), 1)
+        self.assertEqual(pyt["::2"], "a")
+        self.assertIn("::2", pyt)
+
+    def testInsertInvalidShortV6(self):
+        pyt = pytricia.PyTricia()
+        with self.assertRaisesRegex(ValueError, "Invalid key.") as cm:
+            val = pyt.insert(":2:", "a") # should raise an exception
+
+    def testInsertInvalidShortV4(self):
+        pyt = pytricia.PyTricia()
+        with self.assertRaisesRegex(ValueError, "Invalid key.") as cm:
+            val = pyt.insert("192.", "a") # should raise an exception
+
     def testGet(self):
         pyt = pytricia.PyTricia()
         pyt.insert("10.0.0.0/8", "a")


### PR DESCRIPTION
Rejecting an address with fewer than 4 bytes probably made sense when the input was assumed to be a 4-byte integer or a dotted-quad string representing an IPv4 address or prefix.

However, it unnecessarily rejects valid IPv6 addresses like "::2".

This change removes that restriction, and adds tests for both allowing a short valid v6 address, and tests that exceptions are raised for invalid short v6 or v4 addresses for other reasons than purely length.

# Tests

Here's an example of the new tests running without the short address fix:
```
> python3 test.py
..................E................
======================================================================
ERROR: testInsertValidShortV6 (__main__.PyTriciaTests.testInsertValidShortV6)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dmccombs/git/pytricia/test.py", line 288, in testInsertValidShortV6
    val = pyt.insert("::2", "a") # A valid short IPv6 address should succeed
ValueError: Invalid key.

----------------------------------------------------------------------
Ran 35 tests in 0.105s

FAILED (errors=1)
```

And a run with the fix in place:
```
> python3 test.py
...................................
----------------------------------------------------------------------
Ran 35 tests in 0.093s

OK
```